### PR TITLE
feat: Implement Scheduler Reference Architecture

### DIFF
--- a/opendc/models/machine_state.py
+++ b/opendc/models/machine_state.py
@@ -5,7 +5,6 @@ from opendc.util import database
 class MachineState(Model):
     JSON_TO_PYTHON_DICT = {
         'MachineState': {
-            'taskId': 'task_id',
             'machineId': 'machine_id',
             'temperatureC': 'temperature_c',
             'inUseMemoryMb': 'in_use_memory_mb',
@@ -15,7 +14,7 @@ class MachineState(Model):
     }
 
     TABLE_NAME = 'machine_states'
-    COLUMNS = ['id', 'task_id', 'machine_id', 'experiment_id', 'tick', 'temperature_c', 'in_use_memory_mb',
+    COLUMNS = ['id', 'machine_id', 'experiment_id', 'tick', 'temperature_c', 'in_use_memory_mb',
                'load_fraction']
 
     COLUMNS_PRIMARY_KEY = ['id']
@@ -25,12 +24,11 @@ class MachineState(Model):
         """Instantiate a MachineState from a database row (including tick from the TaskState)."""
 
         return cls(
-            task_id=row[1],
-            machine_id=row[2],
-            temperature_c=row[5],
-            in_use_memory_mb=row[6],
-            load_fraction=row[7],
-            tick=row[4]
+            machine_id=row[1],
+            temperature_c=row[4],
+            in_use_memory_mb=row[5],
+            load_fraction=row[6],
+            tick=row[3]
         )
 
     @classmethod

--- a/opendc/models/task.py
+++ b/opendc/models/task.py
@@ -7,14 +7,13 @@ class Task(Model):
             'id': 'id',
             'startTick': 'start_tick',
             'totalFlopCount': 'total_flop_count',
+            'coreCount': 'core_count',
             'jobId': 'job_id',
-            'taskDependencyId': 'task_dependency_id',
-            'parallelizability': 'parallelizability'
         }
     }
 
     TABLE_NAME = 'tasks'
-    COLUMNS = ['id', 'start_tick', 'total_flop_count', 'job_id', 'task_dependency_id', 'parallelizability']
+    COLUMNS = ['id', 'start_tick', 'total_flop_count', 'job_id', 'core_count']
     COLUMNS_PRIMARY_KEY = ['id']
 
     def google_id_has_at_least(self, google_id, authorization_level):


### PR DESCRIPTION
This change implements the changes needed in the webserver for implementing
parts of the Datacenter Scheduling Reference Architecture as published
in SC18.

This change reflects the following changes in the database schema:

- **Removal of `parallelizability` column in `Task`**
    This field was not used by the simulator and we opted to use a field
    describing the amount of cores the task can run on instead.
- **Removal of `task_id` column in `MachineState`**
    This field did not make sense anymore now that a machine can run
    multiple tasks. Fortunately, this field is not used in the frontend.